### PR TITLE
updated karate jar dependencies to prevent vulnerability

### DIFF
--- a/karate-core/pom.xml
+++ b/karate-core/pom.xml
@@ -69,7 +69,7 @@
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>1.5.4</version>
+            <version>1.5.15</version>
         </dependency>         
         <dependency>
             <groupId>org.slf4j</groupId>
@@ -97,7 +97,7 @@
         <dependency>
             <groupId>net.minidev</groupId>
             <artifactId>json-smart</artifactId>
-            <version>2.5.1</version>
+            <version>2.4.11</version>
         </dependency>                                                                                                                                                           													                      
         <dependency>
             <groupId>org.yaml</groupId>


### PR DESCRIPTION
### Description

updated following dependencies to prevent vulnerability in json-smart 2.5.1:
- json-smart: 2.5.1 -> 2.4.11
- ch.qos.logback: 1.5.4 -> 1.5.15

- Relevant Issues : (compulsory)
- Relevant PRs : (optional)
- Type of change :
  - [ ] New feature
  - [ ] Bug fix for existing feature
  - [ ] Code quality improvement
  - [ ] Addition or Improvement of tests
  - [ ] Addition or Improvement of documentation
