### PR TITLE
fix(security): bump netty-bom 4.1.132 → 4.2.13.Final

### DIFF
--- a/karate-core/pom.xml
+++ b/karate-core/pom.xml
@@ -20,7 +20,7 @@
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-bom</artifactId>
-                <version>4.1.132.Final</version>
+                <version>4.2.13.Final</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>


### PR DESCRIPTION
## Summary
- Bumps `netty-bom` from `4.1.132.Final` to `4.2.13.Final` in `karate-core/pom.xml`
- Fixes all 10 Netty CVEs blocking `hyperexecute-postprocessing-service` CI, including CVE-2026-42577 (epoll) which has no 4.1.x backport

## CVEs Fixed
- CVE-2026-41417 (HIGH) — netty-codec-http request-line validation bypass
- CVE-2026-42577 (HIGH) — netty-transport-native-epoll fails to validate
- CVE-2026-42579 (HIGH) — netty-codec-dns input validation
- CVE-2026-42580 (MEDIUM) — netty-codec-http chunk size parser
- CVE-2026-42581 (MEDIUM) — netty-codec-http TE+CL coexistence bypass
- CVE-2026-42583 (HIGH) — netty-codec Lz4FrameDecoder allocation overflow
- CVE-2026-42584 (HIGH) — netty-codec-http HttpClientCodec
- CVE-2026-42585 (MEDIUM) — netty-codec-http malformed header parsing
- CVE-2026-42587 (HIGH) — netty-codec-http/http2 decompression
- CVE-2026-42338 (MEDIUM) — ip-address (fixed via npm upgrade in postprocessing Dockerfile)

## Testing
- Built fat jar with `-P fatjar` profile
- Ran against real HyperExecute Karate test data (job `09bd2375-1c5c-4e4d-9269-245845a75565`)
- Result: **7 features, 19 scenarios, 0 failures** — matches prod report exactly

## Next Steps
After merge: rebuild fat jar, update `hyperexecute-postprocessing-service/report-processor/karate-jars/karate-1.5.4.jar`

Ticket: TE-13544

🤖 Generated with [Claude Code](https://claude.com/claude-code)