### PR TITLE
fix(security): bump netty-bom 4.2.13.Final → 4.2.15.Final

### DIFF
--- a/karate-core/pom.xml
+++ b/karate-core/pom.xml
@@ -20,7 +20,7 @@
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-bom</artifactId>
-                <version>4.2.13.Final</version>
+                <version>4.2.15.Final</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>


### PR DESCRIPTION
## Summary
Bumps `netty-bom` in `karate-core/pom.xml` from `4.2.13.Final` → `4.2.15.Final`.

Clears the 7 Netty CVEs flagging `hyperexecute-postprocessing-service`'s vuln scan (the Netty lives in the shaded Karate report-processor fat jar). All are fixed in Netty `4.2.15.Final`:

- CVE-2026-44249 (HIGH 8.1) — netty-handler
- CVE-2026-44893 (HIGH 7.5) — netty-codec-haproxy
- CVE-2026-45416 (HIGH 7.5) — netty-handler
- CVE-2026-45673 (MED 6.8) — netty-resolver-dns
- CVE-2026-45674 (HIGH 8.7) — netty-resolver-dns
- CVE-2026-47244 (MED 5.3) — netty-codec-http2
- CVE-2026-47691 (HIGH 8.7) — netty-resolver-dns

Mirrors the prior bump (`4.1.132 → 4.2.13`, PR #8).

## Testing
- Built fat jar with `-P fatjar` (JDK 21) — BUILD SUCCESS.
- Verified bundled Netty across handler/codec-http2/resolver-dns/codec-haproxy/transport-native-epoll = `4.2.15.Final`.
- Smoke-tested `java -jar karate-1.5.3.jar` — main class loads cleanly (patch-level Netty bump, API-compatible).

## Next step
Rebuild the fat jar and update `hyperexecute-postprocessing-service/report-processor/karate-jars/` (done in the companion PR).

Ticket: TE-16289

🤖 Generated with [Claude Code](https://claude.com/claude-code)