### PR TITLE
chore(release): bump version 1.5.3 -> 1.5.5

### DIFF
--- a/karate-archetype/pom.xml
+++ b/karate-archetype/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.karatelabs</groupId>
         <artifactId>karate-parent</artifactId>
-        <version>1.5.0</version>
+        <version>1.5.5</version>
     </parent>
     <artifactId>karate-archetype</artifactId>
     <packaging>jar</packaging>

--- a/karate-core/pom.xml
+++ b/karate-core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.karatelabs</groupId>
         <artifactId>karate-parent</artifactId>
-        <version>1.5.3</version>
+        <version>1.5.5</version>
     </parent>
     <artifactId>karate-core</artifactId>
     <packaging>jar</packaging>   

--- a/karate-demo/pom.xml
+++ b/karate-demo/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.karatelabs</groupId>
         <artifactId>karate-parent</artifactId>
-        <version>1.5.0</version>
+        <version>1.5.5</version>
     </parent>
     
     <artifactId>karate-demo</artifactId>

--- a/karate-e2e-tests/pom.xml
+++ b/karate-e2e-tests/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.karatelabs</groupId>
         <artifactId>karate-parent</artifactId>
-        <version>1.5.0</version>
+        <version>1.5.5</version>
     </parent>
     <artifactId>karate-e2e-tests</artifactId>
     <packaging>jar</packaging>

--- a/karate-gatling/pom.xml
+++ b/karate-gatling/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.karatelabs</groupId>
         <artifactId>karate-parent</artifactId>
-        <version>1.5.0</version>
+        <version>1.5.5</version>
     </parent>
     <artifactId>karate-gatling</artifactId>
     <packaging>jar</packaging>

--- a/karate-junit5/pom.xml
+++ b/karate-junit5/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.karatelabs</groupId>
         <artifactId>karate-parent</artifactId>
-        <version>1.5.0</version>
+        <version>1.5.5</version>
     </parent>
     <artifactId>karate-junit5</artifactId>
     <packaging>jar</packaging>

--- a/karate-playwright/pom.xml
+++ b/karate-playwright/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.karatelabs</groupId>
         <artifactId>karate-parent</artifactId>
-        <version>1.5.0</version>
+        <version>1.5.5</version>
     </parent>
 
     <artifactId>karate-playwright</artifactId>

--- a/karate-robot/pom.xml
+++ b/karate-robot/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.karatelabs</groupId>
         <artifactId>karate-parent</artifactId>
-        <version>1.5.0</version>
+        <version>1.5.5</version>
     </parent>
     <artifactId>karate-robot</artifactId>
     <packaging>jar</packaging>  

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>io.karatelabs</groupId>
     <artifactId>karate-parent</artifactId>
-    <version>1.5.3</version>
+    <version>1.5.5</version>
     <packaging>pom</packaging>
     
     <name>${project.artifactId}</name>


### PR DESCRIPTION
## What

Bumps the project version **1.5.3 → 1.5.5** across the root pom and all reactor modules (via `mvn versions:set -DnewVersion=1.5.5 -DprocessAllModules=true`). Also realigns a few module parent refs that were lagging at `1.5.0`, so the whole reactor is consistent.

## Why

So a fresh build produces **`karate-1.5.5.jar`** — a distinctly-versioned artifact to replace the `karate-1.5.4.jar` that shipped with vulnerable Netty in `hyperexecute-postprocessing-service`.

## Netty note

No dependency change here — **`lt-reports` already pins Netty to `4.2.15.Final`** (via `netty-bom` in `dependencyManagement` + Armeria 1.31.2). Verified with `mvn dependency:tree`: `armeria:1.31.2 → netty-handler:4.2.15.Final`. This branch already resolves the 12 Netty CVEs (`CVE-2026-44249/44893/45416/45673/45674/47244/47691/48043/48059/50010/50020/50560`); this PR just advances the version so the patched jar can be cut as 1.5.5.

`mvn validate` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)