### PR TITLE
fix(security): bump jackson-databind 2.18.6 → 2.18.8 (CVE-2026-54512/54513/54514)

### DIFF
--- a/karate-core/pom.xml
+++ b/karate-core/pom.xml
@@ -27,17 +27,17 @@
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-core</artifactId>
-                <version>2.18.9</version>
+                <version>2.18.8</version>
             </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-databind</artifactId>
-                <version>2.18.9</version>
+                <version>2.18.8</version>
             </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-annotations</artifactId>
-                <version>2.18.9</version>
+                <version>2.18.8</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/karate-core/pom.xml
+++ b/karate-core/pom.xml
@@ -27,17 +27,17 @@
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-core</artifactId>
-                <version>2.18.6</version>
+                <version>2.18.9</version>
             </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-databind</artifactId>
-                <version>2.18.6</version>
+                <version>2.18.9</version>
             </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-annotations</artifactId>
-                <version>2.18.6</version>
+                <version>2.18.9</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
## Summary

Bumps the pinned Jackson version in `karate-core/pom.xml` `dependencyManagement` from **2.18.6 → 2.18.8** (jackson-core, jackson-databind, jackson-annotations).

This clears 3 of the 4 `jackson-databind` CVEs flagged by the Prisma Cloud image scan in the downstream `hyperexecute-postprocessing-service` (its shaded `karate-*.jar` bundles jackson-databind):

| CVE | Severity | Score | Patched in (2.x) | Status |
|-----|----------|-------|------------------|--------|
| CVE-2026-54512 | high | 8.1 | 2.18.8 | ✅ fixed |
| CVE-2026-54513 | high | 8.1 | 2.18.8 | ✅ fixed |
| CVE-2026-54514 | medium | 5.3 | 2.18.8 | ✅ fixed |
| CVE-2026-54515 | medium | 5.3 | 2.18.9 / 2.21.5 | ⏳ not yet released |

**Note on CVE-2026-54515:** per the GitHub advisory, the only patched versions are 2.18.9, 2.21.5 (neither published to Maven Central yet) and 3.1.4 (Jackson 3.x — different `tools.jackson` groupId, not a drop-in for Karate's 2.x usage). Staying on the 2.18.x line, **2.18.8 is the highest released patch.** This one CVE will need a follow-up bump to 2.18.9 once it ships.

I initially proposed 2.18.9 but corrected to 2.18.8 since 2.18.9 is not yet on Maven Central (the build fails to resolve it).

## Context
The post-processing service consumes the shaded fat jar built from this branch (`lt-reports`, karate.version 1.5.3). Its CI vulnerability scan fails on the above CVEs because the bundled jackson-databind is 2.18.6.

## Testing
Version-only bump within the same minor line; no source changes. Locally built the `-P fatjar` artifact from this branch to confirm it resolves and packages.