### PR TITLE
[TE-10262]: add CD to publish karate report fatjar to GitHub Packages

### DIFF
--- a/.github/settings.xml
+++ b/.github/settings.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0
+                              https://maven.apache.org/xsd/settings-1.0.0.xsd">
+  <servers>
+    <!-- Credentials used by lt-reports-cd.yml to publish the karate report
+         fatjar to GitHub Packages. GITHUB_ACTOR / GITHUB_TOKEN are injected
+         by the workflow; the built-in GITHUB_TOKEN has packages:write on this
+         repo. -->
+    <server>
+      <id>github</id>
+      <username>${env.GITHUB_ACTOR}</username>
+      <password>${env.GITHUB_TOKEN}</password>
+    </server>
+  </servers>
+</settings>

--- a/.github/workflows/lt-reports-cd.yml
+++ b/.github/workflows/lt-reports-cd.yml
@@ -1,0 +1,75 @@
+name: lt-reports-cd
+
+# Publishes the Karate report-integration fatjar to GitHub Packages on every
+# merge into lt-reports. The post-processing service (LambdatestIncPrivate/
+# hyperexecute-postprocessing-service) downloads it from a fixed coordinate at
+# Docker build time, so there is nothing to version-bump or rename by hand:
+# every merge overwrites the same coordinate, mirroring how the extent report
+# jar is published (extentnativereports-1.10-stage).
+#
+#   coordinate: com.lambdatest:karate-reports:lt-reports
+#   url:        https://maven.pkg.github.com/LambdaTest/karate/com/lambdatest/karate-reports/lt-reports/karate-reports-lt-reports.jar
+
+on:
+  push:
+    branches:
+      - lt-reports
+  workflow_dispatch: {}
+
+jobs:
+  publish:
+    name: Build and publish karate report fatjar
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: git checkout
+        uses: actions/checkout@v4
+
+      - name: set up jdk 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+
+      - name: cache maven packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-maven-
+
+      # Build only karate-core (and its reactor parents) with the fatjar profile,
+      # producing the shaded karate-<version>.jar that bundles com.intuit.karate.Main.
+      - name: build karate-core fatjar
+        run: |
+          mvn -B -ntp clean install -DskipTests \
+            -P pre-release,fatjar \
+            -pl karate-core -am \
+            -Djavacpp.platform=linux-x86_64
+
+      # Deploy the fatjar to GitHub Packages under a fixed coordinate. deploy-file
+      # is used (instead of a plain deploy) so the karate-parent release version
+      # (1.5.x, used for Maven Central) is never touched — the published artifact
+      # is always com.lambdatest:karate-reports:lt-reports regardless of the
+      # internal karate version.
+      - name: publish to GitHub Packages
+        env:
+          GITHUB_ACTOR: ${{ github.actor }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          KARATE_VERSION="$(mvn -q -DforceStdout -f karate-core/pom.xml help:evaluate -Dexpression=project.version)"
+          echo "Built karate-core version: ${KARATE_VERSION}"
+          FATJAR="karate-core/target/karate-${KARATE_VERSION}.jar"
+          test -f "${FATJAR}" || { echo "fatjar not found at ${FATJAR}"; ls -lh karate-core/target; exit 1; }
+          mvn -B -ntp deploy:deploy-file \
+            --settings .github/settings.xml \
+            -Dfile="${FATJAR}" \
+            -DgroupId=com.lambdatest \
+            -DartifactId=karate-reports \
+            -Dversion=lt-reports \
+            -Dpackaging=jar \
+            -DrepositoryId=github \
+            -Durl=https://maven.pkg.github.com/LambdaTest/karate


### PR DESCRIPTION
## What

Adds a CD workflow that publishes the Karate report-integration fatjar to **GitHub Packages** on every merge into `lt-reports`, replacing the current manual process.

- `.github/workflows/lt-reports-cd.yml` — on push to `lt-reports`: builds the `karate-core` fatjar (`-P pre-release,fatjar -pl karate-core -am`), then `mvn deploy:deploy-file` to the **fixed coordinate** `com.lambdatest:karate-reports:lt-reports`. Auth uses the built-in `GITHUB_TOKEN` (`packages: write` on this repo).
- `.github/settings.xml` — Maven server credentials for the deploy (`GITHUB_ACTOR` / `GITHUB_TOKEN`).

## Why

Today the fatjar is built by hand and committed into `hyperexecute-postprocessing-service`, with the version/jar-name bumped manually (and often forgotten — pom said `1.5.3` while the jar was named `1.5.x`). Publishing to a stable coordinate that is overwritten on each merge removes all manual version/naming steps — this mirrors how the extent report jar (`extentnativereports-1.10-stage`) is already published.

The consumer side (post-processing service) downloads from:
```
https://maven.pkg.github.com/LambdaTest/karate/com/lambdatest/karate-reports/lt-reports/karate-reports-lt-reports.jar
```

## Notes
- The published artifact is always `com.lambdatest:karate-reports:lt-reports` regardless of the internal karate version, so the `karate-parent` release version (used for Maven Central) is never touched.
- Package will be **public** (this repo is public); GitHub's Maven registry still requires an authenticated token to download, so the consumer authenticates with a `read:packages` token.

Jira: https://lambdatest.atlassian.net/browse/TE-10262

🤖 Generated with [Claude Code](https://claude.com/claude-code)