### PR TITLE
[TE-10262]: add CD to publish karate report fatjar to GitHub Packages (v2)

### DIFF
--- a/.github/settings.xml
+++ b/.github/settings.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0
+                              https://maven.apache.org/xsd/settings-1.0.0.xsd">
+  <servers>
+    <!-- Credentials used by lt-reports-cd.yml to publish the karate report
+         fatjar to GitHub Packages. GITHUB_ACTOR / GITHUB_TOKEN are injected
+         by the workflow; the built-in GITHUB_TOKEN has packages:write on this
+         repo. -->
+    <server>
+      <id>github</id>
+      <username>${env.GITHUB_ACTOR}</username>
+      <password>${env.GITHUB_TOKEN}</password>
+    </server>
+  </servers>
+</settings>

--- a/.github/workflows/lt-reports-cd.yml
+++ b/.github/workflows/lt-reports-cd.yml
@@ -14,7 +14,6 @@ on:
   push:
     branches:
       - lt-reports
-      - TE-10262-v2   # TEMP: lets the build run on the fix branch; remove before merge
   workflow_dispatch: {}
 
 jobs:
@@ -65,12 +64,11 @@ jobs:
 
       # Deploy the fatjar to GitHub Packages under a fixed coordinate. deploy-file
       # is used (instead of a plain deploy) so the karate-parent release version
-      # (1.5.x, used for Maven Central) is never touched.
-      #
-      # TEMP: publishing is disabled (if: false) while the build is verified on
-      # TE-10262-v2. Remove the `if: ${{ false }}` line to re-enable before merge.
+      # (1.5.x, used for Maven Central) is never touched. Only runs on lt-reports
+      # (not workflow_dispatch from other branches) so the package is published
+      # solely from merges into lt-reports.
       - name: publish to GitHub Packages
-        if: ${{ false }}
+        if: github.ref == 'refs/heads/lt-reports'
         env:
           GITHUB_ACTOR: ${{ github.actor }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/lt-reports-cd.yml
+++ b/.github/workflows/lt-reports-cd.yml
@@ -1,0 +1,88 @@
+name: lt-reports-cd
+
+# Publishes the Karate report-integration fatjar to GitHub Packages on every
+# merge into lt-reports. The post-processing service (LambdatestIncPrivate/
+# hyperexecute-postprocessing-service) downloads it from a fixed coordinate at
+# Docker build time, so there is nothing to version-bump or rename by hand:
+# every merge overwrites the same coordinate, mirroring how the extent report
+# jar is published (extentnativereports-1.10-stage).
+#
+#   coordinate: com.lambdatest:karate-reports:lt-reports
+#   url:        https://maven.pkg.github.com/LambdaTest/karate/com/lambdatest/karate-reports/lt-reports/karate-reports-lt-reports.jar
+
+on:
+  push:
+    branches:
+      - lt-reports
+      - TE-10262-v2   # TEMP: lets the build run on the fix branch; remove before merge
+  workflow_dispatch: {}
+
+jobs:
+  publish:
+    name: Build and publish karate report fatjar
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: git checkout
+        uses: actions/checkout@v4
+
+      - name: set up jdk 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+
+      - name: cache maven packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-maven-
+
+      # Build the karate-core fatjar (shaded karate-<version>.jar bundling
+      # com.intuit.karate.Main). IMPORTANT: only the `fatjar` profile is active.
+      # Activating `pre-release` alongside it merges the two profiles' shade
+      # executions (both use the default execution id) into an invalid config:
+      #   maven-shade-plugin: Cannot find 'resource' in class ServicesResourceTransformer
+      # build-docker.sh keeps the two profiles in separate invocations for the
+      # same reason. `-pl karate-core -am` builds only karate-core and its parent.
+      - name: build karate-core fatjar
+        run: |
+          mvn -B -ntp clean package -DskipTests \
+            -P fatjar \
+            -pl karate-core -am
+
+      - name: verify fatjar
+        run: |
+          KARATE_VERSION="$(mvn -q -DforceStdout -f karate-core/pom.xml help:evaluate -Dexpression=project.version)"
+          echo "Built karate-core version: ${KARATE_VERSION}"
+          FATJAR="karate-core/target/karate-${KARATE_VERSION}.jar"
+          test -f "${FATJAR}" || { echo "fatjar not found at ${FATJAR}"; ls -lh karate-core/target; exit 1; }
+          ls -lh "${FATJAR}"
+
+      # Deploy the fatjar to GitHub Packages under a fixed coordinate. deploy-file
+      # is used (instead of a plain deploy) so the karate-parent release version
+      # (1.5.x, used for Maven Central) is never touched.
+      #
+      # TEMP: publishing is disabled (if: false) while the build is verified on
+      # TE-10262-v2. Remove the `if: ${{ false }}` line to re-enable before merge.
+      - name: publish to GitHub Packages
+        if: ${{ false }}
+        env:
+          GITHUB_ACTOR: ${{ github.actor }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          KARATE_VERSION="$(mvn -q -DforceStdout -f karate-core/pom.xml help:evaluate -Dexpression=project.version)"
+          FATJAR="karate-core/target/karate-${KARATE_VERSION}.jar"
+          mvn -B -ntp deploy:deploy-file \
+            --settings .github/settings.xml \
+            -Dfile="${FATJAR}" \
+            -DgroupId=com.lambdatest \
+            -DartifactId=karate-reports \
+            -Dversion=lt-reports \
+            -Dpackaging=jar \
+            -DrepositoryId=github \
+            -Durl=https://maven.pkg.github.com/LambdaTest/karate


### PR DESCRIPTION
Re-do of #13 (reverted in #14) with the shade build failure fixed.

## What

CD workflow that publishes the Karate report-integration fatjar to **GitHub Packages** on every merge into `lt-reports`.

- `.github/workflows/lt-reports-cd.yml` — on push to `lt-reports`: build the `karate-core` fatjar, then `mvn deploy:deploy-file` to the fixed coordinate `com.lambdatest:karate-reports:lt-reports`. Publish step is guarded `if: github.ref == 'refs/heads/lt-reports'` and auths with the built-in `GITHUB_TOKEN`.
- `.github/settings.xml` — Maven server creds for the deploy.

## What broke in #13 and the fix

The first run failed at the shade goal:
```
maven-shade-plugin: Cannot find 'resource' in class ServicesResourceTransformer
```
The build activated `-P pre-release,fatjar` **together**. Both profiles declare a `maven-shade-plugin` execution with the *default* execution id, so Maven merged their `<transformers>`: fatjar's empty `ServicesResourceTransformer` collided with pre-release's `IncludeResourceTransformer` `<resource>` (netty native libs). `build-docker.sh` never combines the two profiles.

**Fix:** build with only the `fatjar` profile — the base `<build>` has no shade plugin, so `fatjar`-alone is clean:
```
mvn -B -ntp clean package -DskipTests -P fatjar -pl karate-core -am
```

## Verification

Verified build-only (publishing disabled) on `TE-10262-v2`: run [28229180359](https://github.com/LambdaTest/karate/actions/runs/28229180359) **succeeded** — produced `karate-core/target/karate-1.5.3.jar` (71 MB), publish step correctly skipped. This PR then restores the production publish config.

## Consumer
- https://github.com/LambdatestIncPrivate/hyperexecute-postprocessing-service/pull/1369 (downloads this coordinate; merge after the first publish succeeds)

Jira: https://lambdatest.atlassian.net/browse/TE-10262

🤖 Generated with [Claude Code](https://claude.com/claude-code)