### PR TITLE
[TE-10262]: version lt-reports fatjar publish & drop CI on push

### DIFF
--- a/.github/workflows/lt-reports-cd.yml
+++ b/.github/workflows/lt-reports-cd.yml
@@ -2,13 +2,17 @@ name: lt-reports-cd
 
 # Publishes the Karate report-integration fatjar to GitHub Packages on every
 # merge into lt-reports. The post-processing service (LambdatestIncPrivate/
-# hyperexecute-postprocessing-service) downloads it from a fixed coordinate at
-# Docker build time, so there is nothing to version-bump or rename by hand:
-# every merge overwrites the same coordinate, mirroring how the extent report
-# jar is published (extentnativereports-1.10-stage).
+# hyperexecute-postprocessing-service) downloads it from this coordinate at
+# Docker build time.
 #
-#   coordinate: com.lambdatest:karate-reports:lt-reports
-#   url:        https://maven.pkg.github.com/LambdaTest/karate/com/lambdatest/karate-reports/lt-reports/karate-reports-lt-reports.jar
+# GitHub Packages rejects re-publishing an existing version (HTTP 409 Conflict),
+# so the publish version is NOT fixed: it is ${project.version}.${lt.patch.version}
+# where project.version tracks upstream karate (1.5.3) and lt.patch.version is a
+# LambdaTest-fork counter in the root pom that must be bumped on each republish.
+# The downstream consumer must reference the bumped version after each publish.
+#
+#   coordinate: com.lambdatest:karate-reports:<karate.version>.<lt.patch.version>  (e.g. 1.5.3.1)
+#   url:        https://maven.pkg.github.com/LambdaTest/karate/com/lambdatest/karate-reports/1.5.3.1/karate-reports-1.5.3.1.jar
 
 on:
   push:
@@ -62,11 +66,14 @@ jobs:
           test -f "${FATJAR}" || { echo "fatjar not found at ${FATJAR}"; ls -lh karate-core/target; exit 1; }
           ls -lh "${FATJAR}"
 
-      # Deploy the fatjar to GitHub Packages under a fixed coordinate. deploy-file
-      # is used (instead of a plain deploy) so the karate-parent release version
-      # (1.5.x, used for Maven Central) is never touched. Only runs on lt-reports
-      # (not workflow_dispatch from other branches) so the package is published
-      # solely from merges into lt-reports.
+      # Deploy the fatjar to GitHub Packages. deploy-file is used (instead of a
+      # plain deploy) so the karate-parent release version (1.5.x, used for Maven
+      # Central) is never touched. The publish version is the upstream karate
+      # version with the LambdaTest-fork patch appended (project.version.lt.patch.version,
+      # e.g. 1.5.3.1); bump lt.patch.version in the root pom to republish, since
+      # GitHub Packages rejects overwriting an existing version (HTTP 409). Only
+      # runs on lt-reports (not workflow_dispatch from other branches) so the
+      # package is published solely from merges into lt-reports.
       - name: publish to GitHub Packages
         if: github.ref == 'refs/heads/lt-reports'
         env:
@@ -74,13 +81,16 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           KARATE_VERSION="$(mvn -q -DforceStdout -f karate-core/pom.xml help:evaluate -Dexpression=project.version)"
+          LT_PATCH_VERSION="$(mvn -q -DforceStdout -f karate-core/pom.xml help:evaluate -Dexpression=lt.patch.version)"
+          PUBLISH_VERSION="${KARATE_VERSION}.${LT_PATCH_VERSION}"
+          echo "Publishing karate-reports version: ${PUBLISH_VERSION}"
           FATJAR="karate-core/target/karate-${KARATE_VERSION}.jar"
           mvn -B -ntp deploy:deploy-file \
             --settings .github/settings.xml \
             -Dfile="${FATJAR}" \
             -DgroupId=com.lambdatest \
             -DartifactId=karate-reports \
-            -Dversion=lt-reports \
+            -Dversion="${PUBLISH_VERSION}" \
             -Dpackaging=jar \
             -DrepositoryId=github \
             -Durl=https://maven.pkg.github.com/LambdaTest/karate

--- a/.github/workflows/lt-reports-cd.yml
+++ b/.github/workflows/lt-reports-cd.yml
@@ -1,18 +1,12 @@
 name: lt-reports-cd
 
 # Publishes the Karate report-integration fatjar to GitHub Packages on every
-# merge into lt-reports. The post-processing service (LambdatestIncPrivate/
-# hyperexecute-postprocessing-service) downloads it from this coordinate at
-# Docker build time.
+# merge into lt-reports, under coordinate:
 #
-# GitHub Packages rejects re-publishing an existing version (HTTP 409 Conflict),
-# so the publish version is NOT fixed: it is ${project.version}.${lt.patch.version}
-# where project.version tracks upstream karate (1.5.3) and lt.patch.version is a
-# LambdaTest-fork counter in the root pom that must be bumped on each republish.
-# The downstream consumer must reference the bumped version after each publish.
+#   com.lambdatest:karate-reports:${project.version}.${lt.patch.version}
 #
-#   coordinate: com.lambdatest:karate-reports:<karate.version>.<lt.patch.version>  (e.g. 1.5.3.1)
-#   url:        https://maven.pkg.github.com/LambdaTest/karate/com/lambdatest/karate-reports/1.5.3.1/karate-reports-1.5.3.1.jar
+# project.version tracks upstream karate; lt.patch.version is a LambdaTest-fork
+# counter in the root pom that must be bumped on each republish.
 
 on:
   push:
@@ -66,14 +60,8 @@ jobs:
           test -f "${FATJAR}" || { echo "fatjar not found at ${FATJAR}"; ls -lh karate-core/target; exit 1; }
           ls -lh "${FATJAR}"
 
-      # Deploy the fatjar to GitHub Packages. deploy-file is used (instead of a
-      # plain deploy) so the karate-parent release version (1.5.x, used for Maven
-      # Central) is never touched. The publish version is the upstream karate
-      # version with the LambdaTest-fork patch appended (project.version.lt.patch.version,
-      # e.g. 1.5.3.1); bump lt.patch.version in the root pom to republish, since
-      # GitHub Packages rejects overwriting an existing version (HTTP 409). Only
-      # runs on lt-reports (not workflow_dispatch from other branches) so the
-      # package is published solely from merges into lt-reports.
+      # deploy-file (not a plain deploy) keeps the karate-parent release version
+      # untouched. Guarded to lt-reports so only merges publish, never dispatch.
       - name: publish to GitHub Packages
         if: github.ref == 'refs/heads/lt-reports'
         env:

--- a/.github/workflows/lt-reports-ci.yml
+++ b/.github/workflows/lt-reports-ci.yml
@@ -7,9 +7,6 @@ name: lt-reports-ci
 # on PRs before they reach the publish-on-merge workflow.
 
 on:
-  push:
-    branches:
-      - lt-reports
   pull_request:
     branches:
       - lt-reports

--- a/pom.xml
+++ b/pom.xml
@@ -32,6 +32,17 @@
     </developers>       
 
     <properties>
+        <!--
+          LambdaTest fork patch version. The karate-parent <version> above tracks
+          upstream (karatelabs/karate) unchanged; this is a SEPARATE counter for
+          LambdaTest's report-fork changes. It is NOT appended to project.version
+          (which would dirty the Maven Central release coordinate). Instead the
+          lt-reports-cd workflow combines them into the GitHub Packages publish
+          version: ${project.version}.${lt.patch.version} (e.g. 1.5.3.1).
+          BUMP THIS by 1 on every change that needs a republish — GitHub Packages
+          rejects re-publishing an existing version (HTTP 409 Conflict).
+        -->
+        <lt.patch.version>1</lt.patch.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>17</java.version>
         <maven.compiler.version>3.13.0</maven.compiler.version>

--- a/pom.xml
+++ b/pom.xml
@@ -32,16 +32,9 @@
     </developers>       
 
     <properties>
-        <!--
-          LambdaTest fork patch version. The karate-parent <version> above tracks
-          upstream (karatelabs/karate) unchanged; this is a SEPARATE counter for
-          LambdaTest's report-fork changes. It is NOT appended to project.version
-          (which would dirty the Maven Central release coordinate). Instead the
-          lt-reports-cd workflow combines them into the GitHub Packages publish
-          version: ${project.version}.${lt.patch.version} (e.g. 1.5.3.1).
-          BUMP THIS by 1 on every change that needs a republish — GitHub Packages
-          rejects re-publishing an existing version (HTTP 409 Conflict).
-        -->
+        <!-- LambdaTest fork patch counter, kept separate from the upstream-tracking
+             <version> above. lt-reports-cd publishes ${project.version}.${lt.patch.version};
+             bump this on every change that needs a republish. -->
         <lt.patch.version>1</lt.patch.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>17</java.version>


### PR DESCRIPTION
## What

Two fixes for the `lt-reports` report-fatjar pipeline:

1. **Fix the publish 409.** `lt-reports-cd` published under a fixed coordinate (`com.lambdatest:karate-reports:lt-reports`). GitHub Packages treats released versions as immutable, so every run after the first failed with **HTTP 409 Conflict** ([example run](https://github.com/LambdaTest/karate/actions/runs/28230452797/job/83632658796)). It now publishes under `${project.version}.${lt.patch.version}` (e.g. `1.5.3.1`).
2. **Drop CI on push.** `lt-reports-ci` now triggers only on `pull_request` and `workflow_dispatch` (CD still publishes on push to `lt-reports`). Supersedes the closed #17.

## Versioning scheme

- `karate-parent` `<version>` keeps **tracking upstream** karate unchanged (1.5.3).
- New `lt.patch.version` property in the root pom is a **separate LambdaTest-fork counter** — *added, not appended* to the karate version, so the Maven Central release coordinate stays clean.
- Publish version = `project.version` + `.` + `lt.patch.version`.

**To republish after a change: bump `lt.patch.version` in the root pom.**

## ⚠️ Downstream note

The publish coordinate now changes per release, so `hyperexecute-postprocessing-service` (which pulled the fixed `lt-reports` URL) must be pointed at the bumped version after each publish. First publish from this branch lands at `1.5.3.1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)