### PR TITLE
[TE-21657]: bump netty 4.2.16 & jackson 2.18.9 to clear report-fatjar CVEs

### DIFF
--- a/karate-core/pom.xml
+++ b/karate-core/pom.xml
@@ -20,24 +20,24 @@
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-bom</artifactId>
-                <version>4.2.15.Final</version>
+                <version>4.2.16.Final</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-core</artifactId>
-                <version>2.18.8</version>
+                <version>2.18.9</version>
             </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-databind</artifactId>
-                <version>2.18.8</version>
+                <version>2.18.9</version>
             </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-annotations</artifactId>
-                <version>2.18.8</version>
+                <version>2.18.9</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
         <!-- LambdaTest fork patch counter, kept separate from the upstream-tracking
              <version> above. lt-reports-cd publishes ${project.version}.${lt.patch.version};
              bump this on every change that needs a republish. -->
-        <lt.patch.version>1</lt.patch.version>
+        <lt.patch.version>2</lt.patch.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>17</java.version>
         <maven.compiler.version>3.13.0</maven.compiler.version>


### PR DESCRIPTION
## What

Bumps the vulnerable transitive dependencies pinned in `karate-core`'s `dependencyManagement` so the published `karate-reports` fatjar clears the CVEs flagged by the `hyperexecute-postprocessing-service` **DockerfileSecure** vulnerability scan.

| Dependency | Was | Now | Clears |
|---|---|---|---|
| `io.netty:netty-bom` | 4.2.15.Final | **4.2.16.Final** | CVE-2026-55831, CVE-2026-55833, CVE-2026-55851 (CVSS 8.7) |
| `jackson-core` | 2.18.8 | **2.18.9** | — (kept in lockstep) |
| `jackson-databind` | 2.18.8 | **2.18.9** | CVE-2026-59889, GHSA-mhm7-754m-9p8w |
| `jackson-annotations` | 2.18.8 | **2.18.9** | — (kept in lockstep) |

All four fix versions are present on Maven Central (verified HTTP 200).

## Versioning / republish

Per the scheme from #18, `lt.patch.version` is bumped **1 → 2** in the root pom, so `lt-reports-cd` republishes the fatjar as **`com.lambdatest:karate-reports:1.5.3.2`** on merge to `lt-reports`. `karate-parent` `<version>` (1.5.3, upstream-tracking) is left untouched.

## ⚠️ Downstream note

After this merges and CD publishes `1.5.3.2`, `hyperexecute-postprocessing-service` must bump `KARATE_REPORTS_VERSION` **1.5.3.1 → 1.5.3.2** in `DockerfileSecure` (and `Dockerfile` for parity) to pick up the patched jar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)